### PR TITLE
Safe ornament menu

### DIFF
--- a/[Ornamental] Green_Mile_MU/data/config/export/main/asset/green_mile_buildmenu.include.xml
+++ b/[Ornamental] Green_Mile_MU/data/config/export/main/asset/green_mile_buildmenu.include.xml
@@ -29,7 +29,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503000</GUID>
 					<Name>GreenMileOW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_ow.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_ow.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -47,7 +47,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503001</GUID>
 					<Name>GreenMileNW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_nw.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_nw.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -65,7 +65,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503002</GUID>
 					<Name>GreenMileAfrica</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_africa.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_africa.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -84,7 +84,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503003</GUID>
 					<Name>GreenMileFlowersOW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_ow.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_ow.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -102,7 +102,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503004</GUID>
 					<Name>GreenMileFlowersNW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_nw.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_nw.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -120,7 +120,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503005</GUID>
 					<Name>GreenMileFlowersAfrica</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_africa.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_flowers_africa.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -139,7 +139,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503112</GUID>
 					<Name>GreenMileHarborOW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_ow.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_ow.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -157,7 +157,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503113</GUID>
 					<Name>GreenMileHarborNW</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_nw.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_nw.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>
@@ -175,7 +175,7 @@ NOT IN USE AT THE MOMENT
 				<Standard>
 					<GUID>1337503114</GUID>
 					<Name>GreenMileHarborAfrica</Name>
-					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_africa.png</IconFilename>>
+					<IconFilename>data\ui\2kimages\main\3dicons\green_mile_trees_harbor_africa.png</IconFilename>
 				</Standard>
 				<ConstructionCategory>
 					<BuildingList>

--- a/[Ornamental] Green_Mile_MU/data/config/export/main/asset/ornaments_buildmenu_modify.include.xml
+++ b/[Ornamental] Green_Mile_MU/data/config/export/main/asset/ornaments_buildmenu_modify.include.xml
@@ -29,6 +29,15 @@
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx Ornamenten Kategorien OW xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
 	<ModOp Type="addNextSibling" GUID='1010035'>
 		<Asset>
+			<Template>ConstructionCategory</Template>
+			<Values>
+				<Standard>
+					<GUID>1337505000</GUID>
+					<Name>duplicate</Name>
+				</Standard>
+			</Values>
+		</Asset>
+		<Asset>
                           <Template>ConstructionCategory</Template>
                           <Values>
                             <Standard>
@@ -58,9 +67,20 @@
                           </Values>
                         </Asset>
 	</ModOp>
+	<!-- Duplikate (eigenes und Fremdmods) entfernen -->
+	<ModOp Type="remove" Path="//Asset[Values/Standard/GUID='1337505000'][position() < last()]"/>
 	
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx Ornamenten Kategorien NW xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
 	<ModOp Type="addNextSibling" GUID='1010035'>
+		<Asset>
+			<Template>ConstructionCategory</Template>
+			<Values>
+				<Standard>
+					<GUID>1337505001</GUID>
+					<Name>duplicate</Name>
+				</Standard>
+			</Values>
+		</Asset>
 		<Asset>
                           <Template>ConstructionCategory</Template>
                           <Values>
@@ -91,6 +111,9 @@
                           </Values>
                         </Asset>
 	</ModOp>
+	<!-- Duplikate (eigenes und Fremdmods) entfernen -->
+	<ModOp Type="remove" Path="//Asset[Values/Standard/GUID='1337505001'][position() < last()]"/>
+
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx Ornamenten Kategorien Arctic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
 	<ModOp Type="addNextSibling" GUID='1010359'>
 		<Asset>
@@ -577,18 +600,31 @@
 	
 	</ModOp>
 	
-	
-	<ModOp Type="addNextSibling" GUID='25000035' Path="/Values/ConstructionMenu/RegionMenu/Moderate/OrnamentsMode/OrnamentsSource/Categories/Item[Category = '6577']">
+	<ModOp Type="addNextSibling" GUID="25000035">
+		<Asset>
+			<Template>ConstructionCategory</Template>
+			<Values>
+				<Standard>
+					<GUID>1500010221</GUID>
+					<Name>fallback</Name>
+				</Standard>
+			</Values>
+		</Asset>
+	</ModOp>
+
+	<ModOp Type="addNextSibling" GUID='25000035' Path="/Values/ConstructionMenu/RegionMenu/Moderate/OrnamentsMode/OrnamentsSource/Categories[not(Item/Category='1337505000')]/Item[Category = '6577'] | //Values[Standard/GUID='1500010221']">
 		<Item>
 			<Category>1337505000</Category><!-- Moderate Modding Menu -->
 		</Item>
 	</ModOp>
 	
-	<ModOp Type="addNextSibling" GUID='25000035' Path="/Values/ConstructionMenu/RegionMenu/Colony01/OrnamentsMode/OrnamentsSource/Categories/Item[Category = '6621']">
+	<ModOp Type="addNextSibling" GUID='25000035' Path="/Values/ConstructionMenu/RegionMenu/Colony01/OrnamentsMode/OrnamentsSource/Categories[not(Item/Category='1337505001')]/Item[Category = '6621'] | //Values[Standard/GUID='1500010221']">
 		<Item>
 			<Category>1337505001</Category><!-- NW Modding Menu -->
 		</Item>
 	</ModOp>
+
+	<ModOp Type="remove" GUID="1500010221" />
 	
 	
 	<!-- Remove Arctic forrest from vanilla buildmenu -->

--- a/[Ornamental] Green_Mile_MU/modinfo.Json
+++ b/[Ornamental] Green_Mile_MU/modinfo.Json
@@ -2,7 +2,9 @@
   "Version": "1.1",
   "ModID": "Green_Mile_MU",
   "IncompatibleIds": null,
-  "ModDependencies": "Shared_Objects_MU\nhttps://github.com/muggenstuermer/MU_Anno1800_Mod_Collection/releases/latest",
+  "ModDependencies": [ 
+    "Shared_Objects_MU" 
+  ],
   "Category": {
     "Chinese": null,
     "English": "Ornamental",
@@ -55,28 +57,9 @@
       "Russian": null,
       "Spanish": null,
       "Taiwanese": null
-    },
-    {
-      "Chinese": null,
-      "English": null,
-      "French": null,
-      "German": null,
-      "Italian": null,
-      "Japanese": null,
-      "Korean": null,
-      "Polish": null,
-      "Russian": null,
-      "Spanish": null,
-      "Taiwanese": null
     }
   ],
-  "DLCDependencies": [
-    {
-      "DLC": null,
-      "Dependant": null
-    }
-	
-  ],
+  "DLCDependencies": [],
   "CreatorName": "muggenstuermer",
   "CreatorContact": "https://www.nexusmods.com/anno1800/users/74331668",
   "Image" : null


### PR DESCRIPTION
Mir gefällt das Modding Tab. Sowas hatte ich auch schon im Sinne.
Damit deines in mehreren Mods genutzt werden kann, braucht es noch eine kleine Änderung, sodass es kein doppeltes Hinzufügen oder Warnungen gibt.

Kleine Fehler
- `>` zu viel
- `ModDependencies` ist ein Array von IDs für Mod Manager - nicht zur Anzeige.